### PR TITLE
Add support for multiple sessions/decoders per remote host

### DIFF
--- a/netflow9/dump.go
+++ b/netflow9/dump.go
@@ -8,7 +8,7 @@ import (
 func Dump(p *Packet) {
 	fmt.Println("NetFlow version 9 packet")
 	for _, ds := range p.DataFlowSets {
-		fmt.Println("  data set")
+		fmt.Printf("  data set template %d, length: %d\n", ds.Header.ID, ds.Header.Length)
 		if ds.Records == nil {
 			fmt.Printf("    %d raw bytes:\n", len(ds.Bytes))
 			fmt.Println(hex.Dump(ds.Bytes))


### PR DESCRIPTION
Given that multiple remotes might overlap in the templates they specify, it might be useful to have a session per remote connection sending data.