### PR TITLE
v9 produces extra record

### DIFF
--- a/netflow9/packet.go
+++ b/netflow9/packet.go
@@ -403,7 +403,7 @@ func (dfs *DataFlowSet) Unmarshal(r io.Reader, tr TemplateRecord, t *Translate) 
 	buffer.ReadFrom(r)
 
 	dfs.Records = make([]DataRecord, 0)
-	for buffer.Len() > 0 {
+	for buffer.Len() >= 4 { // Continue until only padding alignment bytes left
 		var dr = DataRecord{}
 		dr.TemplateID = tr.TemplateID
 		if err := dr.Unmarshal(bytes.NewBuffer(buffer.Next(tr.Size())), tr.Fields, t); err != nil {


### PR DESCRIPTION
Hey there,

I was processing some netflow v9 and noticed that 31 records were created for a particular netflow packet rather than the 30 found in wireshark. I've made a small change that corrects this issue by assuming each flow record must be at least 4 bytes to avoid interpreting padding (always 3 bytes or less) as an additional record.

<img width="590" alt="screenshot 2016-05-11 10 41 25" src="https://cloud.githubusercontent.com/assets/13948507/15188849/11da92a4-1765-11e6-8ccb-72666757d2dd.png">
