### PR TITLE
v7 doesn't read reserved field

### DIFF
--- a/netflow7/packet.go
+++ b/netflow7/packet.go
@@ -73,6 +73,9 @@ func (h *PacketHeader) Unmarshal(r io.Reader) error {
 	if err := read.Uint32(&h.FlowSequence, r); err != nil {
 		return err
 	}
+	if err := read.Uint32(&h.Reserved, r); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
While parsing v7, I noticed some of the field values were mismatched compared to Wireshark. This reads the unused `reserved` field from the netflow header and the values from this library now match those produced by Wireshark.