### PR TITLE
gofmt correction

### DIFF
--- a/cmd/nf-dump-pcap/main.go
+++ b/cmd/nf-dump-pcap/main.go
@@ -16,13 +16,13 @@ import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/pcap"
 	"github.com/tehmaze/netflow"
-	"github.com/tehmaze/netflow/session"
 	"github.com/tehmaze/netflow/ipfix"
 	"github.com/tehmaze/netflow/netflow1"
 	"github.com/tehmaze/netflow/netflow5"
 	"github.com/tehmaze/netflow/netflow6"
 	"github.com/tehmaze/netflow/netflow7"
 	"github.com/tehmaze/netflow/netflow9"
+	"github.com/tehmaze/netflow/session"
 )
 
 func main() {

--- a/decoder.go
+++ b/decoder.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/tehmaze/netflow/session"
 	"github.com/tehmaze/netflow/ipfix"
 	"github.com/tehmaze/netflow/netflow1"
 	"github.com/tehmaze/netflow/netflow5"
 	"github.com/tehmaze/netflow/netflow6"
 	"github.com/tehmaze/netflow/netflow7"
 	"github.com/tehmaze/netflow/netflow9"
+	"github.com/tehmaze/netflow/session"
 )
 
 // Decoder for NetFlow messages.


### PR DESCRIPTION
When running `gofmt -w .` in the root of the repository, `gofmt` makes two minor changes to the import order.