### PR TITLE
Correct bytes value and set larger UDP receive buffer

### DIFF
--- a/cmd/nf-dump/main.go
+++ b/cmd/nf-dump/main.go
@@ -40,16 +40,21 @@ func main() {
 		log.Fatal(err)
 	}
 
+	if err = server.SetReadBuffer(262144); err != nil {
+	    log.Fatal(err)
+	}
+
 	decoders := make(map[string]*netflow.Decoder)
 	for {
 		buf := make([]byte, 8192)
 		var remote *net.UDPAddr
-		if _, remote, err = server.ReadFromUDP(buf); err != nil {
+		var cnt int
+		if cnt, remote, err = server.ReadFromUDP(buf); err != nil {
 			log.Printf("error reading from %s: %v\n", remote, err)
 			continue
 		}
 
-		log.Printf("received %d bytes from %s\n", len(buf), remote)
+		log.Printf("received %d bytes from %s\n", cnt, remote)
 
 		d, found := decoders[remote.String()]
 		if !found {


### PR DESCRIPTION
Very minor fixes, just for sake of correctness in case of bytes value shown
UDP receive buffer helped me to decrease udp drops in case of "bursty" netflow stream