### PR TITLE
Connect travis-ci to repository.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ addons:
     - libpcap0.8-dev
 
 install:
-  # - go get -v golang.org/x/tools/cmd/vet
-  - go get golang.org/x/tools/cmd/cover
+  # TODO: Add coverage to project after adding tests
+  # - go get golang.org/x/tools/cmd/cover
   - go get -d -v ./...
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ addons:
     - libpcap0.8-dev
 
 install:
-  - go get -v golang.org/x/tools/cmd/vet
+  # - go get -v golang.org/x/tools/cmd/vet
+  - go get golang.org/x/tools/cmd/cover
   - go get -d -v ./...
 
 script:


### PR DESCRIPTION
According to #12 issue, the problem is not in travis-ci, it is in getting link. 

If you open golang.org/x/tools/cmd/vet it will redirects to https://godoc.org/golang.org/x/tools/cmd/vet and says that this page is `Not Found`.

Possibly my PR fixes this issue.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tehmaze/netflow/14)

<!-- Reviewable:end -->
