### PR TITLE
make templates unique per observation-domain-id

### DIFF
--- a/ipfix/decoder_test.go
+++ b/ipfix/decoder_test.go
@@ -1,0 +1,140 @@
+package ipfix
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/tehmaze/netflow/session"
+)
+
+func TestObservationDomainSeparation(t *testing.T) {
+	// rfc7011 requires that different observation domains within a single device
+	// can use the same template ID to refer to different templates.  Send the
+	// ipfix decoder two different templates sharing the same template id with
+	// two different observation domain ids; then confirm that the appropriate
+	// template is used for data from the two observation domains.
+	var od1Template = []byte{
+		// packet Header
+		0x00, 0x0a, // Protocol version: 10
+		0x00, 0x20, // length: 32
+		0x5b, 0x6d, 0x08, 0x1d, // export time: 8/10/2018 03:35:57 UTC
+		0x00, 0x00, 0x00, 0x01, // sequence number: 1
+		0x00, 0x00, 0x00, 0x01, // observation domain id: 1
+
+		// set header
+		0x00, 0x02, // set id: 2
+		0x00, 0x10, // set length: 16
+
+		// Template 1
+		0x01, 0x00, // template id: 256
+		0x00, 0x02, // field count: 2
+		0x00, 0x08, 0x00, 0x04, // Field 1: IP_SRC_ADDR(8), 4 bytes
+		0x00, 0x0c, 0x00, 0x04, // Field 2: IP_DST_ADDR(12), 4 bytes
+
+	}
+
+	var od2Template = []byte{
+		// packet Header
+		0x00, 0x0a, // Protocol version: 10
+		0x00, 0x20, // length: 32
+		0x5b, 0x6d, 0x08, 0x1d, // export time: 8/10/2018 03:35:57 UTC
+		0x00, 0x00, 0x00, 0x01, // sequence number: 1
+		0x00, 0x00, 0x00, 0x02, // observation domain id: 2
+
+		// set header
+		0x00, 0x02, // set id: 2
+		0x00, 0x10, // set length: 16
+
+		// Template 1
+		0x01, 0x00, // template id: 256
+		0x00, 0x02, // field count: 2
+		0x00, 0x0c, 0x00, 0x04, // Field 1: IP_DST_ADDR(12), 4 bytes
+		0x00, 0x08, 0x00, 0x04, // Field 2: IP_SRC_ADDR(8), 4 bytes
+	}
+
+	var od1Data = []byte{
+		// packet Header
+		0x00, 0x0a, // Protocol version: 10
+		0x00, 0x1c, // length: 28
+		0x5b, 0x6d, 0x08, 0x1d, // export time: 8/10/2018 03:35:57 UTC
+		0x00, 0x00, 0x00, 0x01, // sequence number: 1
+		0x00, 0x00, 0x00, 0x01, // observation domain id: 1
+
+		// set header
+		0x01, 0x00, // set id: 256
+		0x00, 0x0c, // set length: 12
+
+		// flow record 1
+		0xbc, 0x41, 0x7e, 0xd5, // src address: 188.65.126.213
+		0x2e, 0x63, 0xa4, 0x12, // dst address: 46.99.164.18
+	}
+
+	// same bytes as od1Data, except for the observation domain id. But because
+	// od2's template 256 has IP_DST_ADDR first, the addresses will be reversed
+	// in the message
+	var od2Data = []byte{
+		// packet Header
+		0x00, 0x0a, // Protocol version: 10
+		0x00, 0x1c, // length: 28
+		0x5b, 0x6d, 0x08, 0x1d, // export time: 8/10/2018 03:35:57 UTC
+		0x00, 0x00, 0x00, 0x01, // sequence number: 1
+		0x00, 0x00, 0x00, 0x02, // observation domain id: 1
+
+		// set header
+		0x01, 0x00, // set id: 256
+		0x00, 0x0c, // set length: 12
+
+		// flow record 1
+		0xbc, 0x41, 0x7e, 0xd5, // dst address: 188.65.126.213
+		0x2e, 0x63, 0xa4, 0x12, // src address: 46.99.164.18
+	}
+
+	s := session.New()
+
+	_, err := Read(bytes.NewBuffer(od1Template), s, nil)
+	if err != nil {
+		t.Errorf("failed to seed session with od1 template: %v", err)
+	}
+
+	_, err = Read(bytes.NewBuffer(od2Template), s, nil)
+	if err != nil {
+		t.Errorf("failed to seed session with od2 template: %v", err)
+	}
+
+	od1Msg, err := Read(bytes.NewBuffer(od1Data), s, nil)
+	if err != nil {
+		t.Errorf("failed to read od1 data: %v", err)
+	}
+
+	if len(od1Msg.DataSets) != 1 || len(od1Msg.DataSets[0].Records) != 1 || len(od1Msg.DataSets[0].Records[0].Fields) != 2 {
+		t.Errorf("unexpected data sets from od1 data: %v", od1Msg.DataSets)
+	}
+
+	od1Fields := od1Msg.DataSets[0].Records[0].Fields
+	if od1Fields[0].Translated == nil || od1Fields[1].Translated == nil {
+		t.Errorf("untranslated fields from od1 data: %v", od1Fields)
+	}
+
+	if od1Fields[0].Translated.InformationElementID != 8 && od1Fields[1].Translated.InformationElementID != 12 {
+		t.Errorf("fields from od1 data in wrong order: %v %v", od1Fields[0].Translated, od1Fields[1].Translated)
+	}
+
+	// Check od2 data in the same way
+	od2Msg, err := Read(bytes.NewBuffer(od2Data), s, nil)
+	if err != nil {
+		t.Errorf("failed to read od2 data: %v", err)
+	}
+
+	if len(od2Msg.DataSets) != 1 || len(od2Msg.DataSets[0].Records) != 1 || len(od2Msg.DataSets[0].Records[0].Fields) != 2 {
+		t.Errorf("unexpected data sets from od2 data: %v", od2Msg.DataSets)
+	}
+
+	od2Fields := od2Msg.DataSets[0].Records[0].Fields
+	if od2Fields[0].Translated == nil || od2Fields[1].Translated == nil {
+		t.Errorf("untranslated fields from od2 data: %v", od2Fields)
+	}
+
+	if od2Fields[0].Translated.InformationElementID != 12 && od2Fields[1].Translated.InformationElementID != 8 {
+		t.Errorf("fields from od2 data in wrong order: %v %v", od2Fields[0].Translated, od2Fields[1].Translated)
+	}
+}

--- a/ipfix/translate.go
+++ b/ipfix/translate.go
@@ -21,25 +21,8 @@ func NewTranslate(s session.Session) *Translate {
 	return &Translate{translate.NewTranslate(s)}
 }
 
-func (t *Translate) Record(dr *DataRecord) error {
-	if t.Session == nil {
-		return nil
-	}
-	var (
-		tm session.Template
-		tr TemplateRecord
-		ok bool
-	)
-	if tm, ok = t.Session.GetTemplate(dr.TemplateID); !ok {
-		if debug {
-			debugLog.Printf("no template for id=%d, can't translate field\n", dr.TemplateID)
-		}
-		return nil
-	}
-	if tr, ok = tm.(TemplateRecord); !ok {
-		return nil
-	}
-	if tr.Fields == nil {
+func (t *Translate) Record(dr *DataRecord, fss FieldSpecifiers) error {
+	if fss == nil {
 		if debug {
 			debugLog.Printf("no fields in template id=%d, can't translate\n", dr.TemplateID)
 		}
@@ -47,10 +30,10 @@ func (t *Translate) Record(dr *DataRecord) error {
 	}
 
 	if debug {
-		debugLog.Printf("translating %d/%d fields\n", len(dr.Fields), len(tr.Fields))
+		debugLog.Printf("translating %d/%d fields\n", len(dr.Fields), len(fss))
 	}
 
-	for i, field := range tr.Fields {
+	for i, field := range fss {
 		if i > len(dr.Fields) {
 			break
 		}

--- a/netflow9/decoder_test.go
+++ b/netflow9/decoder_test.go
@@ -1,0 +1,143 @@
+package netflow9
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/tehmaze/netflow/session"
+)
+
+func TestSourceIDSeparation(t *testing.T) {
+	// rfc3954 section 7 requires that different observation domains within a
+	// single device can use the same template ID to refer to different template
+	// definitions.  So send the netflow9 decoder two different templates sharing
+	// the same template id, but with two different source-ids; then confirm that
+	// the appropriate template is used for data from the two source-ids.
+	var od1Template = []byte{
+		// packet Header
+		0x00, 0x09, // Protocol version: 9
+		0x00, 0x01, // Count: 1
+		0x00, 0x00, 0xff, 0xff, // sysUpTime: 65535 ms
+		0x5b, 0x6d, 0x08, 0x1d, // export time: 8/10/2018 03:35:57 UTC
+		0x00, 0x00, 0x00, 0x01, // sequence number: 1
+		0x00, 0x00, 0x00, 0x01, // source id: 1
+
+		// set header
+		0x00, 0x00, // set id: 0
+		0x00, 0x10, // set length: 16
+
+		// Template 1
+		0x01, 0x00, // template id: 256
+		0x00, 0x02, // field count: 2
+		0x00, 0x08, 0x00, 0x04, // Field 1: IP_SRC_ADDR(8), 4 bytes
+		0x00, 0x0c, 0x00, 0x04, // Field 2: IP_DST_ADDR(12), 4 bytes
+	}
+
+	var od2Template = []byte{
+		// packet Header
+		0x00, 0x09, // Protocol version: 9
+		0x00, 0x01, // Count: 1
+		0x00, 0x00, 0xff, 0xff, // sysUpTime: 65535 ms
+		0x5b, 0x6d, 0x08, 0x1d, // export time: 8/10/2018 03:35:57 UTC
+		0x00, 0x00, 0x00, 0x01, // sequence number: 1
+		0x00, 0x00, 0x00, 0x02, // source id: 2
+
+		// set header
+		0x00, 0x00, // set id: 0
+		0x00, 0x10, // set length: 16
+
+		// Template 1
+		0x01, 0x00, // template id: 256
+		0x00, 0x02, // field count: 2
+		0x00, 0x0c, 0x00, 0x04, // Field 1: IP_DST_ADDR(12), 4 bytes
+		0x00, 0x08, 0x00, 0x04, // Field 2: IP_SRC_ADDR(8), 4 bytes
+	}
+
+	var od1Data = []byte{
+		// packet Header
+		0x00, 0x09, // Protocol version: 9
+		0x00, 0x01, // Count: 1
+		0x00, 0x00, 0xff, 0xff, // sysUpTime: 65535 ms
+		0x5b, 0x6d, 0x08, 0x1d, // export time: 8/10/2018 03:35:57 UTC
+		0x00, 0x00, 0x00, 0x02, // sequence number: 1
+		0x00, 0x00, 0x00, 0x01, // source id: 1
+
+		// set header
+		0x01, 0x00, // set id: 256
+		0x00, 0x0c, // set length: 12
+
+		// flow record 1
+		0xbc, 0x41, 0x7e, 0xd5, // src address: 188.65.126.213
+		0x2e, 0x63, 0xa4, 0x12, // dst address: 46.99.164.18
+	}
+
+	// same bytes as od1Data, except for the observation domain id. But because
+	// od2's template 256 has IP_DST_ADDR first, the addresses will be reversed
+	// in the message
+	var od2Data = []byte{
+		// packet Header
+		0x00, 0x09, // Protocol version: 9
+		0x00, 0x01, // Count: 1
+		0x00, 0x00, 0xff, 0xff, // sysUpTime: 65535 ms
+		0x5b, 0x6d, 0x08, 0x1d, // export time: 8/10/2018 03:35:57 UTC
+		0x00, 0x00, 0x00, 0x02, // sequence number: 1
+		0x00, 0x00, 0x00, 0x02, // source id: 1
+
+		// set header
+		0x01, 0x00, // set id: 256
+		0x00, 0x0c, // set length: 12
+
+		// flow record 1
+		0xbc, 0x41, 0x7e, 0xd5, // dst address: 188.65.126.213
+		0x2e, 0x63, 0xa4, 0x12, // src address: 46.99.164.18
+	}
+
+	s := session.New()
+
+	_, err := Read(bytes.NewBuffer(od1Template), s, nil)
+	if err != nil {
+		t.Errorf("failed to seed session with od1 template: %v", err)
+	}
+
+	_, err = Read(bytes.NewBuffer(od2Template), s, nil)
+	if err != nil {
+		t.Errorf("failed to seed session with od2 template: %v", err)
+	}
+
+	od1Msg, err := Read(bytes.NewBuffer(od1Data), s, nil)
+	if err != nil {
+		t.Errorf("failed to read od1 data: %v", err)
+	}
+
+	if len(od1Msg.DataFlowSets) != 1 || len(od1Msg.DataFlowSets[0].Records) != 1 || len(od1Msg.DataFlowSets[0].Records[0].Fields) != 2 {
+		t.Errorf("unexpected data sets from od1 data: %v", od1Msg.DataFlowSets)
+	}
+
+	od1Fields := od1Msg.DataFlowSets[0].Records[0].Fields
+	if od1Fields[0].Translated == nil || od1Fields[1].Translated == nil {
+		t.Errorf("untranslated fields from od1 data: %v", od1Fields)
+	}
+
+	if od1Fields[0].Translated.Type != 8 && od1Fields[1].Translated.Type != 12 {
+		t.Errorf("fields from od1 data in wrong order: %v %v", od1Fields[0].Translated, od1Fields[1].Translated)
+	}
+
+	// Check od2 data in the same way
+	od2Msg, err := Read(bytes.NewBuffer(od2Data), s, nil)
+	if err != nil {
+		t.Errorf("failed to read od2 data: %v", err)
+	}
+
+	if len(od2Msg.DataFlowSets) != 1 || len(od2Msg.DataFlowSets[0].Records) != 1 || len(od2Msg.DataFlowSets[0].Records[0].Fields) != 2 {
+		t.Errorf("unexpected data sets from od2 data: %v", od2Msg.DataFlowSets)
+	}
+
+	od2Fields := od2Msg.DataFlowSets[0].Records[0].Fields
+	if od2Fields[0].Translated == nil || od2Fields[1].Translated == nil {
+		t.Errorf("untranslated fields from od2 data: %v", od2Fields)
+	}
+
+	if od2Fields[0].Translated.Type != 12 && od2Fields[1].Translated.Type != 8 {
+		t.Errorf("fields from od2 data in wrong order: %v %v", od2Fields[0].Translated, od2Fields[1].Translated)
+	}
+}

--- a/netflow9/translate.go
+++ b/netflow9/translate.go
@@ -26,28 +26,8 @@ func NewTranslate(s session.Session) *Translate {
 	return &Translate{translate.NewTranslate(s)}
 }
 
-func (t *Translate) Record(dr *DataRecord) error {
-	if t.Session == nil {
-		if debug {
-			debugLog.Println("no session, can't translate field")
-		}
-		return nil
-	}
-	var (
-		tm session.Template
-		tr TemplateRecord
-		ok bool
-	)
-	if tm, ok = t.Session.GetTemplate(dr.TemplateID); !ok {
-		if debug {
-			debugLog.Printf("no template for id=%d, can't translate field\n", dr.TemplateID)
-		}
-		return nil
-	}
-	if tr, ok = tm.(TemplateRecord); !ok {
-		return nil
-	}
-	if tr.Fields == nil {
+func (t *Translate) Record(dr *DataRecord, fss FieldSpecifiers) error {
+	if fss == nil {
 		if debug {
 			debugLog.Printf("no fields in template id=%d, can't translate\n", dr.TemplateID)
 		}
@@ -55,10 +35,10 @@ func (t *Translate) Record(dr *DataRecord) error {
 	}
 
 	if debug {
-		debugLog.Printf("translating %d/%d fields\n", len(dr.Fields), len(tr.Fields))
+		debugLog.Printf("translating %d/%d fields\n", len(dr.Fields), len(fss))
 	}
 
-	for i, field := range tr.Fields {
+	for i, field := range fss {
 		if i >= len(dr.Fields) {
 			break
 		}

--- a/session/session.go
+++ b/session/session.go
@@ -12,26 +12,28 @@ type Session interface {
 	Lock()
 	Unlock()
 
-	// To keep track of maximum record sizes per template
-	GetRecordSize(uint16) (size int, found bool)
-	SetRecordSize(uint16, int)
-
 	// To keep track of templates
-	AddTemplate(Template)
-	GetTemplate(uint16) (t Template, found bool)
+	AddTemplate(uint32, Template)
+	GetTemplate(uint32, uint16) (t Template, found bool)
+}
+
+// templates ids are only unique within a sub-device scope that the netflow v9
+// spec calls a "source id" and ipfix calls an "observation domain id". Use the
+// combination of one of these ids and the template id to look up templates.
+type templateKey struct {
+	sourceID   uint32
+	templateID uint16
 }
 
 type basicSession struct {
 	mutex     *sync.Mutex
-	templates map[uint16]Template
-	sizes     map[uint16]int
+	templates map[templateKey]Template
 }
 
 func New() *basicSession {
 	return &basicSession{
 		mutex:     &sync.Mutex{},
-		templates: make(map[uint16]Template, 65536),
-		sizes:     make(map[uint16]int, 65536),
+		templates: make(map[templateKey]Template, 65536),
 	}
 }
 
@@ -43,23 +45,12 @@ func (s *basicSession) Unlock() {
 	s.mutex.Unlock()
 }
 
-func (s *basicSession) GetRecordSize(tid uint16) (size int, found bool) {
-	size, found = s.sizes[tid]
-	return
+func (s *basicSession) AddTemplate(sourceID uint32, t Template) {
+	s.templates[templateKey{sourceID: sourceID, templateID: t.ID()}] = t
 }
 
-func (s *basicSession) SetRecordSize(tid uint16, size int) {
-	if s.sizes[tid] < size {
-		s.sizes[tid] = size
-	}
-}
-
-func (s *basicSession) AddTemplate(t Template) {
-	s.templates[t.ID()] = t
-}
-
-func (s *basicSession) GetTemplate(id uint16) (t Template, found bool) {
-	t, found = s.templates[id]
+func (s *basicSession) GetTemplate(sourceID uint32, templateID uint16) (t Template, found bool) {
+	t, found = s.templates[templateKey{sourceID: sourceID, templateID: templateID}]
 	return
 }
 


### PR DESCRIPTION
Both ipfix and netflow v9 define template IDs as being unique only within an Observation Domain, indicated by the message's Source ID or Observation Domain ID field:
https://tools.ietf.org/html/rfc7011#section-3.4.1
https://tools.ietf.org/html/rfc3954#section-5.2

Flow data received within a given Observation Domain should be interpreted only with templates received from the same Observation Domain; it's possible for different observation domains (linecards, etc) in the same device to send different template definitions with the same template ids.